### PR TITLE
Stops data from one put being left over for subsequent puts

### DIFF
--- a/models/datasources/beanstalkd_source.php
+++ b/models/datasources/beanstalkd_source.php
@@ -346,13 +346,13 @@ class BeanstalkdSource extends DataSource {
 	function logQuery($method, $params) {
 		$this->_queriesCnt++;
 		$this->_queriesTime += $this->took;
-    $this->_queriesLog[] = (array(
+    $this->_queriesLog[] = array(
       'query' => $method,
       'error' => $this->error,
       'took' => $this->took,
       'affected' => 0,
       'numRows' => 0
-    ));
+    );
     if (count($this->_queriesLog) > $this->_queriesLogMax) {
       array_pop($this->_queriesLog);
     }


### PR DESCRIPTION
Stops data from one put being left over for subsequent puts. Previously, if you did

->put(array('foo' => 'bar');
->put(array('bar' => 'foo');

The first Job would have

foo = bar

The second Job would have

foo = bar
bar = foo

And so forth
