### PR TITLE
Stops data from one put being left over for subsequent puts and utilise _queriesLogMax

### DIFF
--- a/models/datasources/beanstalkd_source.php
+++ b/models/datasources/beanstalkd_source.php
@@ -346,13 +346,13 @@ class BeanstalkdSource extends DataSource {
 	function logQuery($method, $params) {
 		$this->_queriesCnt++;
 		$this->_queriesTime += $this->took;
-    $this->_queriesLog[] = (array(
+    $this->_queriesLog[] = array(
       'query' => $method,
       'error' => $this->error,
       'took' => $this->took,
       'affected' => 0,
       'numRows' => 0
-    ));
+    );
     if (count($this->_queriesLog) > $this->_queriesLogMax) {
       array_pop($this->_queriesLog);
     }


### PR DESCRIPTION
2 sets of commit:
1. Stops data from one put being left over for subsequent puts
2. Utilise _queriesLogMax when using logQuery in order to not build up the log forever, which can increase memory usage in long-running scripts (think shells) and cause them to overflow
